### PR TITLE
企業の紹介文として日本語を受け付けられるようにする

### DIFF
--- a/app/models/sponsorship.rb
+++ b/app/models/sponsorship.rb
@@ -146,7 +146,7 @@ class Sponsorship < ApplicationRecord
   end
 
   def word_count
-    profile&.scan(/\w+/)&.size || 0
+    profile&.grapheme_clusters&.size || 0
   end
 
   def policy_agreement

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -45,7 +45,7 @@ ja:
             booth_requested:
               not_eligible: "は選択されたスポンサープランでは対象外です"
             profile:
-              too_long: "が長過ぎます。選択されたプランでは英文 %{maximum} ワード程度が上限となっています。"
+              too_long: "が長過ぎます。選択されたプランでは %{maximum} 文字程度が上限となっています。"
 
   helpers:
     label:
@@ -121,9 +121,9 @@ ja:
           one: 'ブース出展可能'
           other: 'ブース出展可能'
         words_limit:
-          zero: '英文 0 word'
-          one: '英文 1 word'
-          other: '英文およそ %{count} words'
+          zero: '0文字'
+          one: '1文字'
+          other: 'およそ %{count} 文字以内'
         auto_acceptance: '選択されているプラン %{plan} では申し込み後即座に申し込みが確定となります。'
         not_auto_acceptance: '選択されているプラン %{plan} ではスポンサー申込について後日確定となります。申し込み後のアナウンスをお待ちください。'
       plan_sold_out: '受付終了'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,9 +3,9 @@ ja:
   activerecord:
     attributes:
       sponsorship:
-        name: '会社名/組織名 (英語)'
+        name: '会社名/組織名'
         url: 'URL'
-        profile: '紹介文 (英語)'
+        profile: '紹介文'
         booth_requested: 'ブース出展'
         number_of_additional_attendees: '追加Attendeeチケット枚数'
         policy_agreement: 'ポリシーへ同意する'


### PR DESCRIPTION
Fix #2

## やったこと
- 表示文言から "(英語)" を削除
- 上限のカウント方法を単語数ではなく文字数にする
    - エラーメッセージも変更

![image](https://user-images.githubusercontent.com/4487291/167643176-fb08a256-25fa-41a4-b9d9-2d43fef14c7c.png)

![image](https://user-images.githubusercontent.com/4487291/167643346-27045c22-21ed-4076-8bad-cc08f26b6400.png)


