### PR TITLE
MF用に請求書を出力できるようにしたい

### DIFF
--- a/app/controllers/admin/conferences_controller.rb
+++ b/app/controllers/admin/conferences_controller.rb
@@ -42,6 +42,7 @@ class Admin::ConferencesController < Admin::ApplicationController
   end
 
   def billing
+  # https://biz.moneyforward.com/support/invoice/guide/document02/do06.html#ttl01
     @billings = []
 
     @billings << %w[csv_type(変更不可) 行形式 取引先名称 件名 請求日 お支払期限 請求書番号 売上計上日 メモ タグ 小計 消費税 合計金額 取引先敬称 取引先郵便番号 取引先都道府県 取引先住所1 取引先住所2 取引先部署 取引先担当者役職 取引先担当者氏名 自社担当者氏名 備考 振込先 入金ステータス メール送信ステータス 郵送ステータス ダウンロードステータス 品名 品目コード 単価 数量 単位 詳細 金額 源泉徴収 品目消費税率]

--- a/app/controllers/admin/conferences_controller.rb
+++ b/app/controllers/admin/conferences_controller.rb
@@ -1,4 +1,6 @@
 class Admin::ConferencesController < Admin::ApplicationController
+  TAX_RATE = 0.1
+
   before_action :require_unrestricted_staff, only: [:index, :new, :create]
   before_action :set_conference, only: [:show, :edit, :update, :destroy, :attendees_keeper, :sponsors_yml, :sponsors_json, :asset_urls, :table_view, :billing]
 
@@ -53,9 +55,9 @@ class Admin::ConferencesController < Admin::ApplicationController
     sponsorships = @conference.sponsorships.active.includes_contacts.includes(:plan).order(:plan_id, :id)
 
     sponsorships.each.with_index(1) do |sponsor, i|
-      subtotal = "#{sponsor.plan.price_text&.delete('万円')}0000".to_i
+      subtotal = sponsor.plan.price
       subtotal += booth_price if sponsor.booth_assigned
-      tax = (subtotal * 0.1).to_i
+      tax = (subtotal * TAX_RATE).to_i
 
       @billings << [30101, '請求書', sponsor.billing_contact.organization, "#{@conference.name} 協賛のご請求", billing_day.strftime('%Y/%m/%d'), (billing_day + 1.month).end_of_month.strftime('%Y/%m/%d'),"#{billing_day.strftime("%Y%m%d")}-#{format("%03<number>d", number: i)}", billing_day.strftime('%Y/%m/%d'), sponsor.plan.name,  nil, subtotal, tax, subtotal + tax, sponsor.billing_contact.organization, nil, sponsor.billing_contact.address, nil, nil, sponsor.billing_contact.unit, '', sponsor.billing_contact.name, nil, '払込手数料は、御社のご負担とさせていただきます。'] + Array.new(12)
 

--- a/app/controllers/admin/conferences_controller.rb
+++ b/app/controllers/admin/conferences_controller.rb
@@ -1,6 +1,6 @@
 class Admin::ConferencesController < Admin::ApplicationController
   before_action :require_unrestricted_staff, only: [:index, :new, :create]
-  before_action :set_conference, only: [:show, :edit, :update, :destroy, :attendees_keeper, :sponsors_yml, :sponsors_json, :asset_urls, :table_view]
+  before_action :set_conference, only: [:show, :edit, :update, :destroy, :attendees_keeper, :sponsors_yml, :sponsors_json, :asset_urls, :table_view, :billing]
 
   def index
     @conferences = Conference.all
@@ -39,6 +39,46 @@ class Admin::ConferencesController < Admin::ApplicationController
         [asset.filename, asset.download_url]
       end,
     }.to_json
+  end
+
+  def billing
+    @billings = []
+
+    @billings << %w[csv_type(変更不可) 行形式 取引先名称 件名 請求日 お支払期限 請求書番号 売上計上日 メモ タグ 小計 消費税 合計金額 取引先敬称 取引先郵便番号 取引先都道府県 取引先住所1 取引先住所2 取引先部署 取引先担当者役職 取引先担当者氏名 自社担当者氏名 備考 振込先 入金ステータス メール送信ステータス 郵送ステータス ダウンロードステータス 品名 品目コード 単価 数量 単位 詳細 金額 源泉徴収 品目消費税率]
+
+    billing_day = params[:billing_day] ? Date.parse(params[:billing_day]) : Date.today
+    booth_price = params[:booth_price].to_i
+
+    sponsorships = @conference.sponsorships.active.includes_contacts.includes(:plan).order(:plan_id, :id)
+
+    sponsorships.each.with_index(1) do |sponsor, i|
+      subtotal = "#{sponsor.plan.price_text&.delete('万円')}0000".to_i
+      subtotal += booth_price if sponsor.booth_assigned
+      tax = (subtotal * 0.1).to_i
+
+      @billings << [30101, '請求書', sponsor.billing_contact.organization, "#{@conference.name} 協賛のご請求", billing_day.strftime('%Y/%m/%d'), (billing_day + 1.month).end_of_month.strftime('%Y/%m/%d'),"#{billing_day.strftime("%Y%m%d")}-#{format("%03<number>d", number: i)}", billing_day.strftime('%Y/%m/%d'), sponsor.plan.name,  nil, subtotal, tax, subtotal + tax, sponsor.billing_contact.organization, nil, sponsor.billing_contact.address, nil, nil, sponsor.billing_contact.unit, '', sponsor.billing_contact.name, nil, '払込手数料は、御社のご負担とさせていただきます。'] + Array.new(12)
+
+      @billings << [30101, '品目'] + Array.new(26) + ["#{@conference.name} 協賛費用 (#{sponsor.plan.name})", nil, subtotal, 1, nil, nil, subtotal, '含まない', '10%']
+
+      if sponsor.booth_assigned
+        @billings << [30101, '品目'] + Array.new(26) + ["#{@conference.name} 協賛費用 (ブース出展)", nil, booth_price, 1, nil, nil, booth_price, '含まない', '10%']
+      end
+    end
+
+    respond_to do |format|
+      format.html do
+        render :billing
+      end
+      format.csv do
+        billing_csv = CSV.generate(row_sep: "\r\n") do |csv|
+          @billings.each do |billing|
+            csv << billing
+          end
+        end
+
+        send_data(billing_csv, filename: "#{@conference.name.underscore.gsub(' ', '_')}_billing.csv")
+      end
+    end
   end
 
   def new

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -26,4 +26,11 @@ class Plan < ApplicationRecord
     # TODO:
     (words_limit || 0) * 1.1
   end
+
+  # Used in billing CSV
+  # TODO; Should be replaced with integer price?
+  # This method doesn't work when price_text is something like '25万5千円'
+  def price
+    "#{price_text&.delete('万円')}0000".to_i
+  end
 end

--- a/app/views/admin/conferences/billing.html.haml
+++ b/app/views/admin/conferences/billing.html.haml
@@ -1,0 +1,23 @@
+%nav{aria: {label: 'breadcrumb'}}
+  %ol.breadcrumb
+    %li.breadcrumb-item= link_to @conference.name, conference_path(@conference)
+    %li.breadcrumb-item.active{aria: {current: 'page'}} Billing
+
+.d-md-flex.justify-content-between
+  %h3 Billing
+
+.row
+  .col-12
+    .card.responsive-table
+      .card-header Table
+      %div{style: 'overflow-x: scroll;'}
+        %table.card-body.table.table-hover.table-small{style: 'border-collapse: collapse; white-space: nowrap;width: 100%;'}
+          %thead
+            %tr
+              - @billings[0].each do |head|
+                %th{scope: :col}= head
+          %tbody
+            - @billings[1..].each do |sponsorship|
+              %tr
+                - sponsorship.each do |col|
+                  %td= col

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,7 @@ require "action_view/railtie"
 require "action_cable/engine"
 # require "sprockets/railtie"
 # require "rails/test_unit/railtie"
+require 'csv'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
         get :sponsors_json
         get :asset_urls
         get :table_view
+        get :billing
       end
 
       resource :booth_assignment, only: %i(show update)


### PR DESCRIPTION
とりあえず最低限動く状態にはなったと思うけどひどいのでなんとかしてほしい（雑）
なんでbillingにしたのかも思い出せない...好きに変えてどうぞ！（）

- `/admin/conferences/2022/billing` で請求情報のテーブル表示
- `/admin/conferences/2022/billing.csv` でcsv落とせる
  - 以下パラメータ指定できるとよい
    - 請求日: `billing_day` (YYYYMMDD)
    - ブース費用: `booth_price`

# サンプルCSV
- [kaigi_on_rails_2022_test_billing.csv](https://github.com/kaigionrails/sponsor-app/files/9093382/kaigi_on_rails_2022_test_billing.csv)


# マニュアル
- https://biz.moneyforward.com/support/invoice/guide/document02/do06.html#ttl01