### PR TITLE
display cc-email address

### DIFF
--- a/app/views/admin/sponsorships/show.html.haml
+++ b/app/views/admin/sponsorships/show.html.haml
@@ -184,6 +184,11 @@
         %p.card-text
           #{@sponsorship.contact.name}
           = mail_to @sponsorship.contact.email, @sponsorship.contact.email
+        - if @sponsorship.contact.email_cc
+          %p.card-text
+            = t('activerecord.models.contact.email_cc')
+            %br
+            #{@sponsorship.contact.email_cc}
         %p.card-text
           - if @sponsorship.contact.unit
             = @sponsorship.contact.unit


### PR DESCRIPTION
display sponsorship email_cc address.
email_cc is free style form(e.g. `aa@email.com bb@email.com` . So, just display in the view.

![image](https://github.com/user-attachments/assets/e4b39fdb-3f70-418a-bd2e-b5fab4970a94)
