### PR TITLE
Link to template README in logo upload description

### DIFF
--- a/app/views/sponsorships/_form.html.haml
+++ b/app/views/sponsorships/_form.html.haml
@@ -177,7 +177,7 @@
     .form-group
       %h3= t('.logo')
 
-      %p= t('.logo_help')
+      %p= t('.logo_help_html')
 
     .form-group.sponsorships_form_asset_file{data: {session_endpoint: user_conference_sponsorship_asset_file_path, session_endpoint_method: sponsorship.asset_file&.persisted? ? 'PUT': 'POST'}}
       = form.hidden_field :asset_file_id

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -140,8 +140,10 @@ en:
         Please provide a short introduction of your company. Note that the length of the introduction will vary depending on the sponsorship plan you chose.
       logo: 'Logo'
       download_logo: '(Download previously uploaded file)'
-      logo_help: |
-        Upload your company logo file for the sponsors page in our website, and the venue onsite. Please make sure your file is in vector format (like .ai, .eps, .svg). If you have multiple files, archive them into a .zip file.
+      logo_help_html: |
+        Upload your company logo file for the sponsors page in our website, and the venue onsite.
+        There are specific format requirements for the logo image file.
+        Please refer to <a href="https://esa-pages.io/p/sharing/14929/posts/628/b8d3eb89cc8ad85d0573.html">the template README</a> before submitting.
       others_help: |
         Use the following field for anything you want let us know in advance.
       tickets: 'Attendee Tickets'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -142,9 +142,10 @@ ja:
         ウェブサイトや会場に掲載するためのスポンサーの情報をご提供ください。
       logo: 'ロゴ'
       download_logo: '(以前にアップロードしたファイルをダウンロードする)'
-      logo_help: |
-        Webサイトや会場にて掲示するため、ロゴファイルをアップロードしてください。形式はベクター形式 (.ai, .svg, .eps, .pdf 等) でお願い致します。
-        複数ファイルになる場合、zip 形式で圧縮ください。
+      logo_help_html: |
+        Webサイトや会場にて掲示するため、ロゴファイルをアップロードしてください。
+        ロゴファイル画像には規定の仕様形式がございます。
+        <a href="https://esa-pages.io/p/sharing/14929/posts/628/b8d3eb89cc8ad85d0573.html">テンプレートREADME</a>をご確認の上、提出をお願いいたします。
       tickets: 'Attendee チケット'
       tickets_included_in_plan: 'スポンサープランに含まれている枚数'
       tickets_additionally_request: '追加する枚数'


### PR DESCRIPTION
We provide a template README for the logo file starting from fiscal year 2025.

![logo_help_html_ja](https://github.com/user-attachments/assets/23053817-0198-4a82-94da-55417b768e6b)

![logo_help_html_en](https://github.com/user-attachments/assets/8c829b1f-0ea8-44fd-ad7c-b6a0dadb2bfb)
