### PR TITLE
Push Docker image to ap-northeast-1 ECR for Lambda

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,12 +18,21 @@ jobs:
           aws-region: us-west-2
           role-skip-session-tagging: false
           role-to-assume: "arn:aws:iam::861452569180:role/GhaDockerPushToEcr"
-      - id: login-ecr
+      - id: login-ecr-usw2
+        uses: aws-actions/amazon-ecr-login@19d944daaa35f0fa1d3f7f8af1d3f2e5de25c5b7 # v2.1.4
+      - uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
+        with:
+          aws-region: ap-northeast-1
+          role-skip-session-tagging: false
+          role-to-assume: "arn:aws:iam::861452569180:role/GhaDockerPushToEcr"
+      - id: login-ecr-apne1
         uses: aws-actions/amazon-ecr-login@19d944daaa35f0fa1d3f7f8af1d3f2e5de25c5b7 # v2.1.4
       - id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
-          images: "${{ steps.login-ecr.outputs.registry }}/sponsor-app"
+          images: |
+            ${{ steps.login-ecr-usw2.outputs.registry }}/sponsor-app
+            ${{ steps.login-ecr-apne1.outputs.registry }}/sponsor-app
           tags: |
             type=sha,format=long,prefix=
             type=raw,value=latest
@@ -35,6 +44,9 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: ${{ steps.meta.outputs.tags }}
+          # prevent manifest from being pushed instead of image on the specified tags for Lambda
+          provenance: false
+          sbom: false
 
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What
Push the image to both us-west-2 and ap-northeast-1 so it can be consumed by Lambda in ap-northeast-1. Disable provenance and SBOM attestations on the build to keep the tagged refs as plain image manifests (Lambda rejects OCI image indices).