### PR TITLE
Allow image/png,image/jpeg only as Logo

### DIFF
--- a/app/javascript/user_sponsorship_asset_file_form.tsx
+++ b/app/javascript/user_sponsorship_asset_file_form.tsx
@@ -87,7 +87,7 @@ document.addEventListener("DOMContentLoaded", () => {
           existingFileId={existingFileId}
           sessionEndpoint={sessionEndpoint}
           sessionEndpointMethod={sessionEndpointMethod}
-          accept="image/svg,image/svg+xml,application/pdf,application/zip,.ai,.eps"
+          accept="image/png,image/jpeg"
           onFileChange={onFileChange}
         />
       );

--- a/app/models/sponsorship_asset_file.rb
+++ b/app/models/sponsorship_asset_file.rb
@@ -6,15 +6,6 @@ class SponsorshipAssetFile < ApplicationRecord
   ALLOWED_CONTENT_TYPES = %w[
     image/jpeg
     image/png
-    image/gif
-    image/webp
-    image/svg+xml
-    application/pdf
-    application/zip
-    application/x-zip-compressed
-    application/postscript
-    application/illustrator
-    application/octet-stream
   ].freeze
 
   belongs_to :sponsorship, optional: true


### PR DESCRIPTION
スポンサー画像テンプレートにて、次のようにお伝えしているため、PNGとJPEGのみに制限したいです。

> 受付ができる画像形式は PNG形式、JPEG形式となります
それ以外の画像形式を提出された場合は再提出をお願いすることがあります。あらかじめご了承ください

