### PR TITLE
apply kaigionrails 2026 theme

### DIFF
--- a/app/stylesheets/styles/config/_base.sass
+++ b/app/stylesheets/styles/config/_base.sass
@@ -23,6 +23,9 @@ nav.navbar.navbar-expand-lg.navbar-dark
   background-color: $color_navy
   box-shadow: $nav-shadow
 
+nav.navbar.navbar-expand-lg.navbar-light
+  background-color: $color_pink
+
 nav.navbar.navbar-expand-lg a,
 nav.navbar.navbar-expand-lg a.dropdown-item,
 .navbar-dark .navbar-nav .nav-link
@@ -46,6 +49,7 @@ nav.navbar.navbar-expand-lg a.dropdown-item
 .btn-primary
   background-color: $btn-primary-bg
   border-color: $btn-primary-border
+  color: $white !important
   &:hover
     background-color: $btn-primary-bg-hover
     border-color: $btn-primary-border-hover
@@ -64,6 +68,9 @@ nav.navbar.navbar-expand-lg a.dropdown-item
   border-color: $btn-primary-border-hover
   box-shadow: 0 0 0 0.2rem rgba($btn-primary-bg, .5)
 
+.btn-secondary
+  color: $white !important
+
 .dropdown-item.active, .dropdown-item:active
   color: #fff
   background-color: $btn-primary-bg
@@ -81,3 +88,22 @@ h1, h2, h3, .h2, h3
 .form-group
   label
     font-weight: 600
+
+.alert-info
+  a
+    color: $color_pink
+
+.card
+  color: $black
+  a
+    color: $color_pink
+
+.breadcrumb
+  a
+    color: $color_pink
+
+.pre-json
+  color: $white
+
+.plan-table
+  color: $white

--- a/app/stylesheets/styles/config/_variables.sass
+++ b/app/stylesheets/styles/config/_variables.sass
@@ -11,15 +11,17 @@ $whitegrey: #A9A9A9
 // Theming Colors
 //////////////////////
 $color_navy: oklch(26% 0.0100 39.33)
+$color_pink: #ff2e9b
+$color_green: #ceff05
 $color_red: #eb0064
 $color_yellow: #ff6
 $color_midgray: #ccc
 $color_lightgray: #eee
 
-$color-base: $color_navy
-$color-main: $color_lightgray
+$color-base: $black
+$color-main: $white
 $color-main-light: #6c6c81
-$color-accent: $color_red
+$color-accent: $color_pink
 $color-reversal: $color_lightgray
 
 
@@ -45,8 +47,8 @@ $default-text: $color-main
 $reversal-text: $color-reversal
 $muted-text: $color-main-light
 
-$link: #1E4EC4
-$link-hover: #1E4DAD
+$link: $color_green
+$link-hover: darken($color_green, 10%)
 
 $border: $color-main-light
 
@@ -65,7 +67,7 @@ $nav-toggler-border: transparent
 // button
 $btn-primary-bg: $color-accent
 $btn-primary-border: transparent
-$btn-primary-bg-hover: darken($color-accent, 10%)
+$btn-primary-bg-hover: darken($color_pink, 15%)
 $btn-primary-border-hover: transparent
 
 // schedule

--- a/app/views/admin/form_descriptions/show.html.haml
+++ b/app/views/admin/form_descriptions/show.html.haml
@@ -13,6 +13,6 @@
 %div
   %h4 fallback_options
   - if @form_description.fallback_options.present? && @form_description.fallback_options.any?
-    %pre= JSON.pretty_generate(@form_description.fallback_options)
+    %pre.pre-json= JSON.pretty_generate(@form_description.fallback_options)
   - else
     %em (not configured)

--- a/app/views/admin/plans/index.html.haml
+++ b/app/views/admin/plans/index.html.haml
@@ -10,7 +10,7 @@
 
 - if @plans.any?
   .table-responsive
-    %table.table.table-bordered.table-striped
+    %table.table.table-bordered.table-striped.plan-table
       %thead
         %tr
           %th Rank

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -19,7 +19,7 @@
     = vite_client_tag
     = vite_typescript_tag 'admin'
   %body
-    %nav.navbar.navbar-expand-lg.navbar-light.bg-light
+    %nav.navbar.navbar-expand-lg.navbar-light
       %a.navbar-brand{href: '/'} #{Rails.application.config.x.org_name} Sponsorships Admin
       %button.navbar-toggler{type: :button, data: {toggle: :collapse, target: '#navbarNavAltMarkup'}, aria: {controls: 'navbarNavAltMarkup', expanded: false, label: 'Toggle navigation'}}
         %span.navbar-toggler-icon


### PR DESCRIPTION
文字色都合で可読性が低い問題を取り急ぎ解決する調整を入れました。(後からデザイナーチームから指摘があればもちろん変更すべきかと思います！) 

# 旧(現状)

<img width="1515" height="791" alt="スクリーンショット 2026-05-10 1 58 25" src="https://github.com/user-attachments/assets/210db2c2-a4f5-4f41-8861-5490f6204733" />


# 管理画面

<img width="1466" height="1049" alt="スクリーンショット 2026-05-10 1 34 40" src="https://github.com/user-attachments/assets/b19ff135-5405-4b2b-b956-9ddac6e8ee79" />

<img width="1466" height="1076" alt="スクリーンショット 2026-05-10 1 35 20" src="https://github.com/user-attachments/assets/e6590d11-a699-4013-8c5c-6fa9dd75d5ef" />


# 利用者側画面

<img width="1454" height="1020" alt="スクリーンショット 2026-05-10 1 34 25" src="https://github.com/user-attachments/assets/f2448567-c081-4991-b42a-448247ccf6b8" />
<img width="1325" height="692" alt="スクリーンショット 2026-05-10 1 34 01" src="https://github.com/user-attachments/assets/588963ea-66f1-49d3-8f0c-04c239f10bf9" />
