### PR TITLE
Pin pnpm version to 9 in CI

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -15,7 +15,7 @@ jobs:
           bundler-cache: true
       - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
         with:
-          version: latest
+          version: "9"
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           cache: pnpm


### PR DESCRIPTION
CIの `Run pnpm install --frozen-lockfile` のステップで落ちるようになったので対処したい。

## 概要

  CI で pnpm のバージョンを `latest` 指定していたため、pnpm 10 が自動採用され CI が落ちるようになった。
  pnpm のバージョンを `"9"` に固定することで対応した。

  ## 原因

  `.github/workflows/_test.yml` にて `version: latest` を指定していたところ、
  pnpm 10 が `latest` として配信されるようになり CI に自動的に採用された（2026年5月10日頃から失敗を確認）。

  pnpm 10 では `pnpm-workspace.yaml` の `allowBuilds: false` の扱いが変更され、
  従来は黙って無視していた挙動がハードエラーになった。
  これにより `@parcel/watcher` と `esbuild` のビルドスクリプトが禁止されているとして
  CI が失敗するようになった。

  ## 対応

  `version: latest` を `version: "9"` に固定し、pnpm 10 への自動アップグレードを防止した。