### PR TITLE
Align SponsorshipAssetFile content_type spec with kaigionrails restriction

### DIFF
--- a/spec/models/sponsorship_asset_file_spec.rb
+++ b/spec/models/sponsorship_asset_file_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe SponsorshipAssetFile, type: :model do
     end
 
     describe 'content_type' do
-      %w[image/jpeg image/png image/gif image/webp image/svg+xml application/pdf application/zip application/x-zip-compressed application/postscript application/illustrator application/octet-stream].each do |type|
+      %w[image/jpeg image/png].each do |type|
         it "allows #{type}" do
           file = FactoryBot.build(:sponsorship_asset_file, sponsorship:, content_type: type)
           file.valid?
@@ -28,7 +28,7 @@ RSpec.describe SponsorshipAssetFile, type: :model do
         end
       end
 
-      %w[text/html text/plain application/javascript style/css].each do |type|
+      %w[image/gif image/webp image/svg+xml application/pdf application/zip application/x-zip-compressed application/postscript application/illustrator application/octet-stream text/html text/plain application/javascript style/css].each do |type|
         it "rejects #{type}" do
           file = FactoryBot.build(:sponsorship_asset_file, sponsorship:, content_type: type)
           file.valid?


### PR DESCRIPTION
ALLOWED_CONTENT_TYPES was narrowed to image/jpeg and image/png only (191a97b), so move the previously allowed types to the rejects list.