### PR TITLE
Tweak 2026 theme tokens and admin navbar/breadcrumb contrast

### DIFF
--- a/app/stylesheets/styles/config/_base.sass
+++ b/app/stylesheets/styles/config/_base.sass
@@ -25,6 +25,24 @@ nav.navbar.navbar-expand-lg.navbar-dark
 
 nav.navbar.navbar-expand-lg.navbar-light
   background-color: $color_pink
+  .navbar-brand
+    color: $white
+    &:hover, &:focus
+      color: $white
+  .navbar-nav .nav-link
+    color: $white
+    &:hover, &:focus
+      color: rgba($white, .85)
+  .navbar-nav .show > .nav-link,
+  .navbar-nav .active > .nav-link
+    color: $white
+  .navbar-text
+    color: $white
+    a
+      color: $white
+  .navbar-toggler
+    color: rgba($white, .7)
+    border-color: rgba($white, .3)
 
 nav.navbar.navbar-expand-lg a,
 nav.navbar.navbar-expand-lg a.dropdown-item,
@@ -90,17 +108,24 @@ h1, h2, h3, .h2, h3
     font-weight: 600
 
 .alert-info
-  a
+  a:not(.btn)
     color: $color_pink
 
 .card
   color: $black
-  a
+  a:not(.btn)
     color: $color_pink
 
 .breadcrumb
-  a
+  background-color: $color-bg-card
+  border: 1px solid $color-line
+  a:not(.btn)
     color: $color_pink
+
+.breadcrumb-item
+  color: $color-text-muted
+  &.active
+    color: $white
 
 .pre-json
   color: $white

--- a/app/stylesheets/styles/config/_variables.sass
+++ b/app/stylesheets/styles/config/_variables.sass
@@ -6,7 +6,6 @@ $black: #000
 $white: #FFF
 $whitegrey: #A9A9A9
 
-// from https://github.com/kaigionrails/kaigi-on-rails-2022
 //////////////////////
 // Theming Colors
 //////////////////////
@@ -29,15 +28,20 @@ $color-reversal: $color_lightgray
 // UI Colors
 //////////////////////
 
-$primary: #558abf
+$primary: $color_pink
 $secondary: #e7ebef !default
-$success: #7eb2b5 !default
-$info: #53aeb3 !default
-$warning: #cad041 !default
-$danger: #f47288 !default
+$success: $color_green !default
+$info: $color_green !default
+$warning: $color_yellow !default
+$danger: $color_red !default
 $gray: #9e9e9e !default
 $dark: #343a40 !default
 $disabled: #e2e2e2
+
+$color-bg-card: rgba($black, .4)
+$color-line: rgba($white, .4)
+$color-text-muted: rgba($white, .7)
+$color-stripe-gray: #525252
 
 // background-color
 $base-bg: $color-base


### PR DESCRIPTION
## What

Followup #49 

- _variables.sass: align Bootstrap UI colors ($primary/$success/$info/$warning/$danger) with 2026 key colors, and add 2026 semi-transparent tokens ($color-bg-card, $color-line, $color-text-muted, $color-stripe-gray) following kaigionrails-site2026.
- _base.sass: force white-based text on the admin navbar (.navbar-light) so the brand/links remain legible on the pink background.
- _base.sass: exclude .btn from the .card/.alert-info/.breadcrumb anchor color override so .btn-danger/.btn-warning keep their Bootstrap text colors instead of turning pink.
- _base.sass: restyle .breadcrumb on the dark body to use the new bg-card/line tokens with white-based item text.