### PR TITLE
ロゴテンプレREADMEのリンクを例年開催用に変更する

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -186,7 +186,7 @@ en:
       logo_help_html: |
         Upload your company logo file for the sponsors page in our website, and the venue onsite.
         There are specific format requirements for the logo image file.
-        Please refer to <a href="https://esa-pages.io/p/sharing/14929/posts/628/b8d3eb89cc8ad85d0573.html">the template README</a> before submitting.
+        Please refer to <a href="https://esa-pages.io/p/sharing/14929/posts/846/ce6470e4fec9d63ae08e.html">the template README</a> before submitting.
       others_help: |
         Use the following field for anything you want let us know in advance.
       note: 'Others'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -187,7 +187,7 @@ ja:
       logo_help_html: |
         Webサイトや会場にて掲示するため、ロゴファイルをアップロードしてください。
         ロゴファイル画像には規定の仕様形式がございます。
-        <a href="https://esa-pages.io/p/sharing/14929/posts/628/b8d3eb89cc8ad85d0573.html">テンプレートREADME</a>をご確認の上、提出をお願いいたします。
+        <a href="https://esa-pages.io/p/sharing/14929/posts/846/ce6470e4fec9d63ae08e.html">テンプレートREADME</a>をご確認の上、提出をお願いいたします。
       tickets: 'Attendee チケット'
       tickets_included_in_plan: 'スポンサープランに含まれている枚数'
       tickets_additionally_request: '追加する枚数'


### PR DESCRIPTION
ここ

<img width="1721" height="313" alt="image" src="https://github.com/user-attachments/assets/8a80aa2b-2cb6-42df-99c4-0dbb882436d5" />
