### PR TITLE
.table をダークテーマに対応

### DIFF
--- a/app/stylesheets/styles/config/_base.sass
+++ b/app/stylesheets/styles/config/_base.sass
@@ -202,6 +202,7 @@ h2
 .table
   color: $white
   th, td
+    padding: 0.75rem 1.25rem
     border-top-color: $color-line
     vertical-align: middle
   thead th

--- a/app/stylesheets/styles/config/_base.sass
+++ b/app/stylesheets/styles/config/_base.sass
@@ -199,6 +199,29 @@ h2
 .plan-table
   color: $white
 
+.table
+  color: $white
+  th, td
+    border-top-color: $color-line
+    vertical-align: middle
+  thead th
+    background-color: rgba($white, .08)
+    border-bottom-color: $color-line
+    color: $white
+    font-weight: 600
+  a:not(.btn)
+    color: $link
+    &:hover,
+    &:focus
+      color: $link-hover
+
+.table-hover tbody tr:hover
+  color: $white
+  background-color: rgba($white, .06)
+
+.table-striped tbody tr:nth-of-type(odd)
+  background-color: rgba($white, .03)
+
 .card-header
   background-color: rgba($white, .1)
   border-bottom: 1px solid $color-line


### PR DESCRIPTION
## Summary

- `.table` の文字色・ボーダー色をダークテーマに合わせる
- `thead th` にうっすら帯と白文字を付けて見出しを視認可能に
- `.table-hover` / `.table-striped` も連動でダーク調に
- table 内のリンクは緑 (`$link`) で統一

これで `admin/broadcasts#show` の Recipients テーブルなど、これまで thead や本文が暗色で読めなかった箇所がきちんと表示される。

## Test plan

- [x] `/admin/conferences/:slug/broadcasts/:id` の Recipients テーブルで Name / Email / status が読めるか確認
- [x] hover で行がうっすら明るくなるか確認
- [ ] その他 admin 系で table を使う画面（plans, expense_reports, attendees_keeper, table_view 等）で崩れ・読みにくさが無いか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)