### PR TITLE
デザイン微調整: list-group h2・admin sponsorship show 改善

### DIFF
--- a/app/stylesheets/styles/config/_base.sass
+++ b/app/stylesheets/styles/config/_base.sass
@@ -148,6 +148,12 @@ h2
     margin-bottom: 2.5rem
     background-image: repeating-linear-gradient(-45deg, $white 0, $white 10px, transparent 10px, transparent 18px)
 
+// .list-group-item 内の h2 では装飾線を出さない
+.list-group-item h2
+  margin-bottom: 1.25rem
+  &::after
+    content: none
+
 .form-group
   margin-bottom: 1.75rem
   label

--- a/app/views/admin/sponsorships/show.html.haml
+++ b/app/views/admin/sponsorships/show.html.haml
@@ -6,12 +6,12 @@
     %li.breadcrumb-item Sponsorships
     %li.breadcrumb-item.active{aria: {current: 'page'}}= @sponsorship.name
 
-.d-md-flex.justify-content-between
-  %h3 #{@sponsorship.name}
-  %div
-    = link_to "Edit", edit_conference_sponsorship_path(@conference, @sponsorship), class: 'btn btn-primary'
-    = link_to "History", conference_sponsorship_editing_histories_path(@conference, @sponsorship), class: 'btn btn-secondary'
-    =# link_to "Compose Email", front_mail_to_link(@sponsorship.contact.email, from: @conference.contact_email_address, cc: @sponsorship.contact.email_ccs), class: 'btn btn-info', target: '_blank'
+%h2= @sponsorship.name
+
+.mb-4
+  = link_to "Edit", edit_conference_sponsorship_path(@conference, @sponsorship), class: 'btn btn-primary'
+  = link_to "History", conference_sponsorship_editing_histories_path(@conference, @sponsorship), class: 'btn btn-secondary'
+  =# link_to "Compose Email", front_mail_to_link(@sponsorship.contact.email, from: @conference.contact_email_address, cc: @sponsorship.contact.email_ccs), class: 'btn btn-info', target: '_blank'
 
 .row
   .col-md-8
@@ -137,7 +137,7 @@
                     = link_to "Exhibitor", @sponsorship.tito_booth_staff_discount_code.dashboard_orders_url
                   - if @sponsorship.tito_booth_paid_discount_code
                     = link_to "Exhibitor (Paid)", @sponsorship.tito_booth_paid_discount_code.dashboard_orders_url
-        .card
+        .card.mt-2
           %h5.card-header
             Requests
           .card-body
@@ -237,7 +237,7 @@
     .card
       .card-header.d-flex.justify-content-between
         %h5.my-auto Notes
-        = link_to "Show All", conference_sponsorship_staff_notes_path(@conference, @sponsorship), class: 'btn btn-default small'
+        = link_to "Show All", conference_sponsorship_staff_notes_path(@conference, @sponsorship), class: 'btn btn-default btn-sm'
       %ul.list-group.list-group-flush
         %li.list-group-item
           = render 'admin/sponsorship_staff_notes/form', staff_note: @new_staff_note


### PR DESCRIPTION
## Summary

マージ後に気付いた細かな漏れの追従対応。

- `.list-group-item` 内の h2 から斜線装飾を外し、装飾線分の余白を margin で補填
- `admin/sponsorships#show`：
  - スポンサー名を h3 → h2 にして flex の外に出し、斜線装飾をフル幅に
  - Edit / History ボタンを左寄せ単独配置にし `mb-4` で下マージン
  - Requests カードに `.mt-2` を追加して他カードと並ぶ余白に
  - Show All ボタンの `small` クラスを `btn-sm` に置き換えてちゃんと小サイズに

## Test plan

- [x] sponsorships#show（ユーザー側）でお知らせ一覧の h2 から斜線が消えて余白が自然か確認
- [x] `/admin/conferences/:slug/sponsorships/:id` でスポンサー名の斜線がフル幅・Edit/History ボタンが左寄せ・Requests カードが詰まらず並んでいるか確認
- [x] Show All ボタンが「小サイズ」として描画されているか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)